### PR TITLE
chore: Optimize loop in _calculateAmounts() [SUP-8897]

### DIFF
--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -512,7 +512,7 @@ contract SuperVault is BaseStrategy, ISuperVault {
         returns (uint256[] memory amounts)
     {
         amounts = new uint256[](weights.length);
-        for (uint256 i = 0; i < weights.length; i++) {
+        for (uint256 i; i < weights.length; ++i) {
             amounts[i] = totalOutputAmount.mulDiv(weights[i], TOTAL_WEIGHT, Math.Rounding.Down);
         }
     }


### PR DESCRIPTION
## Problem

Some loops can be optimized to save gas:

[_calculateAmounts()](https://github.com/superform-xyz/SuperVaults/blob/99382c369aa68a2e5666e2ee4045f32cd8bc3f3e/src/SuperVault.sol#L506-L518)

[_filterNonZeroWeights()](https://github.com/superform-xyz/SuperVaults/blob/99382c369aa68a2e5666e2ee4045f32cd8bc3f3e/src/SuperVault.sol#L525-L551)

## Solution

Optimize for loops by applying these changes:

don't initialize the loop counter variable as there is no need to initialize it to zero because it is the default value

cache the array length outside a loop as it saves reading it on each iteration

increment i variable with ++i statement