### PR TITLE
chore: Change param location in _filterNonZeroWeights() to calldata

### DIFF
--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -523,8 +523,8 @@ contract SuperVault is BaseStrategy, ISuperVault {
     /// @return filteredIds Array of filtered Superform IDs
     /// @return filteredWeights Array of filtered weights
     function _filterNonZeroWeights(
-        uint256[] memory superformIds,
-        uint256[] memory weights
+        uint256[] calldata superformIds,
+        uint256[] calldata weights
     )
         internal
         pure


### PR DESCRIPTION
Change the storage location of the parameters in `_filterNonZeroWeights()` from `memory` to `calldata` for gas optimization.