### PR TITLE
fix: prevent duplicate id parameters in addToWhitelist [sup 9346]

### DIFF
--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -713,6 +713,8 @@ contract SuperVault is BaseStrategy, ISuperVault {
     /// @notice Adds a superform ID to the whitelist array
     /// @param superformId The Superform ID to add
     function _addToWhitelist(uint256 superformId) internal {
+        if (whitelistedSuperformIds[superformId]) revert SUPERFORM_ALREADY_WHITELISTED();
+        
         whitelistedSuperformIds[superformId] = true;
         whitelistedSuperformIdArray.push(superformId);
     }

--- a/src/interfaces/ISuperVault.sol
+++ b/src/interfaces/ISuperVault.sol
@@ -80,6 +80,9 @@ interface ISuperVault is IERC1155Receiver {
     /// @notice Error thrown when a superform ID is not whitelisted
     error SUPERFORM_NOT_WHITELISTED();
 
+    /// @notice Error thrown when a superform is already whitelisted
+    error SUPERFORM_ALREADY_WHITELISTED();
+
     //////////////////////////////////////////////////////////////
     //                  EVENTS                                   //
     //////////////////////////////////////////////////////////////

--- a/test/SuperVault.t.sol
+++ b/test/SuperVault.t.sol
@@ -138,12 +138,6 @@ contract SuperVaultTest is ProtocolActions {
             underlyingSuperformIds,
             weights
         );
-        uint256[] memory superformIds = new uint256[](1);
-        superformIds[0] = allSuperformIds[3];
-        bool[] memory isWhitelisted = new bool[](1);
-        isWhitelisted[0] = true;
-
-        ISuperVault(superVault).setWhitelist(superformIds, isWhitelisted);
 
         uint256[] memory isWhitelistedResult = ISuperVault(superVault).getWhitelist();
         assertEq(isWhitelistedResult[0], allSuperformIds[0], "Whitelist not set correctly");
@@ -616,6 +610,13 @@ contract SuperVaultTest is ProtocolActions {
     function test_superVault_rebalance_newVault() public {
         vm.startPrank(deployer);
         SOURCE_CHAIN = ETH;
+
+        uint256[] memory superformIds = new uint256[](1);
+        superformIds[0] = allSuperformIds[3];
+        bool[] memory isWhitelisted = new bool[](1);
+        isWhitelisted[0] = true;
+
+        ISuperVault(superVault).setWhitelist(superformIds, isWhitelisted);
 
         uint256 amount = 10_000e6;
         // Perform a direct deposit to the SuperVault

--- a/test/SuperVault.t.sol
+++ b/test/SuperVault.t.sol
@@ -611,13 +611,6 @@ contract SuperVaultTest is ProtocolActions {
         vm.startPrank(deployer);
         SOURCE_CHAIN = ETH;
 
-        uint256[] memory superformIds = new uint256[](1);
-        superformIds[0] = allSuperformIds[3];
-        bool[] memory isWhitelisted = new bool[](1);
-        isWhitelisted[0] = true;
-
-        ISuperVault(superVault).setWhitelist(superformIds, isWhitelisted);
-
         uint256 amount = 10_000e6;
         // Perform a direct deposit to the SuperVault
         _directDeposit(SUPER_VAULT_ID1, amount);


### PR DESCRIPTION
could check the superformId isn't already present to prevent adding duplicates
(in that case whitelistedSuperformIdArray[] will have the same entry twice which might give some weird results later on)