### PR TITLE
refactor: use enumerable set instead of array for superformId whitelist [sup 9346][sup 9347]

### DIFF
--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Address } from "openzeppelin/contracts/utils/Address.sol";
 import { Math } from "openzeppelin/contracts/utils/math/Math.sol";
+import { EnumerableSet } from "openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { SafeERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ERC20 } from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
@@ -27,10 +28,11 @@ import { ITokenizedStrategy } from "tokenized-strategy/interfaces/ITokenizedStra
 /// @dev Inherits from BaseStrategy and implements ISuperVault and IERC1155Receiver
 /// @author Superform Labs
 contract SuperVault is BaseStrategy, ISuperVault {
-    using Math for uint256;
-    using DataLib for uint256;
-    using SafeERC20 for ERC20;
+    using EnumerableSet for EnumerableSet.UintSet;
     using SafeERC20 for IERC20;
+    using SafeERC20 for ERC20;
+    using DataLib for uint256;
+    using Math for uint256;
 
     //////////////////////////////////////////////////////////////
     //                     STATE VARIABLES                      //
@@ -68,6 +70,8 @@ contract SuperVault is BaseStrategy, ISuperVault {
 
     /// @notice Array of whitelisted Superform IDs for easy access
     uint256[] public whitelistedSuperformIdArray;
+
+    EnumerableSet.UintSet whitelistedSuperformIdsSet;
 
     /// @notice Array of Superform IDs in the vault
     uint256[] public superformIds;

--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -715,10 +715,8 @@ contract SuperVault is BaseStrategy, ISuperVault {
     /// @notice Adds a superform ID to the whitelist array
     /// @param superformId The Superform ID to add
     function _addToWhitelist(uint256 superformId) internal {
-        if (!whitelistedSuperformIdsSet.contains(superformId)) {
-            whitelistedSuperformIds[superformId] = true;
-            whitelistedSuperformIdsSet.add(superformId);
-        }
+        whitelistedSuperformIds[superformId] = true;
+        whitelistedSuperformIdsSet.add(superformId);
     }
 
     /// @notice Removes a superform ID from the whitelist array

--- a/src/SuperVault.sol
+++ b/src/SuperVault.sol
@@ -68,9 +68,7 @@ contract SuperVault is BaseStrategy, ISuperVault {
     /// @notice Mapping to track whitelisted Superform IDs
     mapping(uint256 => bool) public whitelistedSuperformIds;
 
-    /// @notice Array of whitelisted Superform IDs for easy access
-    uint256[] public whitelistedSuperformIdArray;
-
+    /// @notice Set of whitelisted Superform IDs for easy access
     EnumerableSet.UintSet whitelistedSuperformIdsSet;
 
     /// @notice Array of Superform IDs in the vault
@@ -319,7 +317,7 @@ contract SuperVault is BaseStrategy, ISuperVault {
 
     /// @inheritdoc ISuperVault
     function getWhitelist() external view override returns (uint256[] memory) {
-        return whitelistedSuperformIdArray;
+        return whitelistedSuperformIdsSet.values();
     }
 
     /// @inheritdoc IERC1155Receiver
@@ -717,25 +715,16 @@ contract SuperVault is BaseStrategy, ISuperVault {
     /// @notice Adds a superform ID to the whitelist array
     /// @param superformId The Superform ID to add
     function _addToWhitelist(uint256 superformId) internal {
-        whitelistedSuperformIds[superformId] = true;
-        whitelistedSuperformIdArray.push(superformId);
+        if (!whitelistedSuperformIdsSet.contains(superformId)) {
+            whitelistedSuperformIds[superformId] = true;
+            whitelistedSuperformIdsSet.add(superformId);
+        }
     }
 
     /// @notice Removes a superform ID from the whitelist array
     /// @param superformId The Superform ID to remove
     function _removeFromWhitelist(uint256 superformId) internal {
         whitelistedSuperformIds[superformId] = false;
-
-        uint256 length = whitelistedSuperformIdArray.length;
-        // Find and remove the superformId from the array
-        for (uint256 i; i < length; ++i) {
-            if (whitelistedSuperformIdArray[i] == superformId) {
-                // Move the last element to the position being deleted
-                whitelistedSuperformIdArray[i] = whitelistedSuperformIdArray[length - 1];
-                // Remove the last element
-                whitelistedSuperformIdArray.pop();
-                break;
-            }
-        }
+        whitelistedSuperformIdsSet.remove(superformId);
     }
 }


### PR DESCRIPTION
Remove unnecessary array loop in `_removeFromWhiteList()` by making `whitelistedSuperformIds` an enumerable set instead of an array.

This also prevents duplicate entries from being added. 