### PR TITLE
refactor: use abi.encodeCall() instead of encodeWithSelector() 

### DIFF
--- a/src/SuperVaultFactory.sol
+++ b/src/SuperVaultFactory.sol
@@ -116,7 +116,7 @@ contract SuperVaultFactory is ISuperVaultFactory, AccessControl {
         /// @dev set pending management to deployer
         /// @dev deployer will have to accept management in SuperVault
         (bool success,) = address(superVault).call(
-            abi.encodeWithSelector(ITokenizedStrategy.setPendingManagement.selector, msg.sender)
+            abi.encodeCall(ITokenizedStrategy.setPendingManagement, (msg.sender))
         );
         if (!success) {
             revert FAILED_TO_SET_PENDING_MANAGEMENT();


### PR DESCRIPTION
Use `abi.encodeCall()` instead of `encodeWithSelector()` in `createSuperVault()` as it is more secure.

All tests still passing. 